### PR TITLE
Improve set image from Resources.resx

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -9,7 +9,7 @@
 ## Rules
 
 - Follow the pattern of what you already see in the code.
-- When adding new classes/methods/changing existing code: check the functionality of the templates by creating a new project based on them.
+- When adding new classes/methods/changing existing code: check the functionality of new extensions on all versions of Revit if the API has changed.
 
 ## Naming of features and functionality
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -19,3 +19,15 @@ The naming should be descriptive and direct, giving a clear idea of the function
 
 1. DotNet 6 SDK or newer
 2. Visual Studio 2022 / JetBrains Rider 2021.3 or newer
+
+## Life cycle
+
+Revit version support - 5 years.
+
+Package version format:
+
+RevitVersion.MajorVersion.BuildNumber
+
+- The first field is the Revit version the library was compiled for.
+- The second field is promoted after a new version of Revit is released.
+- The third field is promoted when new extensions are released before publishing to NuGet.

--- a/Nice3point.Revit.Extensions/RibbonExtensions.cs
+++ b/Nice3point.Revit.Extensions/RibbonExtensions.cs
@@ -57,7 +57,7 @@ public static class RibbonExtensions
     public static PushButton AddPushButton(this RibbonPanel panel, Type command, string buttonText)
     {
         var pushButtonData = new PushButtonData(command.FullName, buttonText, Assembly.GetAssembly(command).Location, command.FullName);
-        return (PushButton) panel.AddItem(pushButtonData);
+        return (PushButton)panel.AddItem(pushButtonData);
     }
 
     /// <summary>
@@ -69,7 +69,7 @@ public static class RibbonExtensions
     public static PulldownButton AddPullDownButton(this RibbonPanel panel, string name, string buttonText)
     {
         var pushButtonData = new PulldownButtonData(name, buttonText);
-        return (PulldownButton) panel.AddItem(pushButtonData);
+        return (PulldownButton)panel.AddItem(pushButtonData);
     }
 
     /// <summary>
@@ -81,7 +81,7 @@ public static class RibbonExtensions
     public static SplitButton AddSplitButton(this RibbonPanel panel, string name, string buttonText)
     {
         var pushButtonData = new SplitButtonData(name, buttonText);
-        return (SplitButton) panel.AddItem(pushButtonData);
+        return (SplitButton)panel.AddItem(pushButtonData);
     }
 
     /// <summary>
@@ -93,7 +93,7 @@ public static class RibbonExtensions
     public static RadioButtonGroup AddRadioButtonGroup(this RibbonPanel panel, string name)
     {
         var pushButtonData = new RadioButtonGroupData(name);
-        return (RadioButtonGroup) panel.AddItem(pushButtonData);
+        return (RadioButtonGroup)panel.AddItem(pushButtonData);
     }
 
     /// <summary>
@@ -105,7 +105,7 @@ public static class RibbonExtensions
     public static ComboBox AddComboBox(this RibbonPanel panel, string name)
     {
         var pushButtonData = new ComboBoxData(name);
-        return (ComboBox) panel.AddItem(pushButtonData);
+        return (ComboBox)panel.AddItem(pushButtonData);
     }
 
     /// <summary>
@@ -117,7 +117,7 @@ public static class RibbonExtensions
     public static TextBox AddTextBox(this RibbonPanel panel, string name)
     {
         var pushButtonData = new TextBoxData(name);
-        return (TextBox) panel.AddItem(pushButtonData);
+        return (TextBox)panel.AddItem(pushButtonData);
     }
 
     /// <summary>
@@ -130,6 +130,28 @@ public static class RibbonExtensions
     {
         var pushButtonData = new PushButtonData(command.FullName, buttonText, Assembly.GetAssembly(command).Location, command.FullName);
         return pullDownButton.AddPushButton(pushButtonData);
+    }
+
+    /// <summary>
+    ///     Adds a 16x16px-96dpi image from the URI source
+    /// </summary>
+    /// <param name="button">Button to which the icon will be added</param>
+    /// <param name="uri">Relative path to the icon</param>
+    /// <example>button.SetImage("/RevitAddIn;component/Resources/Icons/RibbonIcon16.png")</example>
+    public static void SetImage(this RibbonButton button, string uri)
+    {
+        button.Image = new BitmapImage(new Uri(uri, UriKind.Relative));
+    }
+
+    /// <summary>
+    ///     Adds a 32x32px-96dpi image from the URI source
+    /// </summary>
+    /// <param name="button">Button to which the icon will be added</param>
+    /// <param name="uri">Relative path to the icon</param>
+    /// <example>button.SetLargeImage("/RevitAddIn;component/Resources/Icons/RibbonIcon32.png")</example>
+    public static void SetLargeImage(this RibbonButton button, string uri)
+    {
+        button.LargeImage = new BitmapImage(new Uri(uri, UriKind.Relative));
     }
 
     /// <summary>

--- a/Nice3point.Revit.Extensions/RibbonExtensions.cs
+++ b/Nice3point.Revit.Extensions/RibbonExtensions.cs
@@ -137,7 +137,7 @@ public static class RibbonExtensions
     /// </summary>
     /// <param name="button">Button to which the icon will be added</param>
     /// <para name="bitmap">Image from resources</para>
-    /// <example>button.SetImage("Resources.RibbonIcon.png")</example>
+    /// <example>button.SetImage("Resources.RibbonIcon")</example>
     public static void SetImage(this RibbonButton button, Bitmap bitmap)
     {
         button.Image = ConvertFromImage(bitmap).Resize(16);
@@ -148,7 +148,7 @@ public static class RibbonExtensions
     /// </summary>
     /// <param name="button">Button to which the icon will be added</param>
     /// <param name="bitmap">Image from resources</param>
-    /// <example>button.SetLargeImage("Resources.RibbonIcon.png")</example>
+    /// <example>button.SetLargeImage("Resources.RibbonIcon")</example>
     public static void SetLargeImage(this RibbonButton button, Bitmap bitmap)
     {
         button.LargeImage = ConvertFromImage(bitmap).Resize(32);

--- a/Readme.md
+++ b/Readme.md
@@ -174,13 +174,13 @@ panel.AddTextBox("Button name");
 
 The **SetImage()** method adds an image to the RibbonButton.
 ```c#
-button.SetImage("Resources.RibbonIcon16.png");
+button.SetImage("Resources.RibbonIcon");
 ```
 
 The **SetLargeImage()** method adds a large image to the RibbonButton.
 
 ```c#
-button.SetLargeImage("Resources.RibbonIcon32.png");
+button.SetLargeImage("Resources.RibbonIcon");
 ```
 
 ### <a id="UnitExtensions">Unit Extensions</a>

--- a/Readme.md
+++ b/Readme.md
@@ -173,15 +173,14 @@ panel.AddTextBox("Button name");
 ```
 
 The **SetImage()** method adds an image to the RibbonButton.
-
 ```c#
-button.SetImage("/RevitAddIn;component/Resources/Icons/RibbonIcon16.png");
+button.SetImage("Resources.RibbonIcon16.png");
 ```
 
 The **SetLargeImage()** method adds a large image to the RibbonButton.
 
 ```c#
-button.SetLargeImage("/RevitAddIn;component/Resources/Icons/RibbonIcon32.png");
+button.SetLargeImage("Resources.RibbonIcon32.png");
 ```
 
 ### <a id="UnitExtensions">Unit Extensions</a>

--- a/Readme.md
+++ b/Readme.md
@@ -173,11 +173,20 @@ panel.AddTextBox("Button name");
 ```
 
 The **SetImage()** method adds an image to the RibbonButton.
+
+```c#
+button.SetImage("/RevitAddIn;component/Resources/Icons/RibbonIcon16.png");
+```
+
 ```c#
 button.SetImage("Resources.RibbonIcon");
 ```
 
 The **SetLargeImage()** method adds a large image to the RibbonButton.
+
+```c#
+button.SetLargeImage("/RevitAddIn;component/Resources/Icons/RibbonIcon32.png");
+```
 
 ```c#
 button.SetLargeImage("Resources.RibbonIcon");

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "6.0.0",
     "rollForward": "latestMinor",
-    "allowPrerelease": false
+    "allowPrerelease": true
   }
 }


### PR DESCRIPTION
**Summary of the Pull Request**
- Improve quick set image from resources
- global.json support .NET 6 preview release

**What is this about:** 
Can quick set image from bitmap in resources and automatic resize image
**Description:** 

Only need add image `100*100` pixel or `32*32` pixel to resources

**Sample:**
- Add image to resource
![image](https://user-images.githubusercontent.com/31106432/149690614-fe6940e9-adc6-40ef-bd9a-81c83e4557ad.png)
- Change image build action to resource
![image](https://user-images.githubusercontent.com/31106432/149690911-510bd1e8-a5ea-4f54-8847-9fba49111d11.png)
- Set image by function
```c#
button.SetImage("Resources.dev1");
button.SetLargeImage("Resources.dev1");
```
## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
