### PR TITLE
Add Revit 2019 Support to RevitExtensions R20–R26

### DIFF
--- a/RevitExtensions.sln
+++ b/RevitExtensions.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{CE054458-C119-4C03-BF1C-6D267460E960}") = "Build", "build\Build.csproj", "{6A41E6AD-B176-4658-9474-C6D192CAE9AA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Build", "build\Build.csproj", "{6A41E6AD-B176-4658-9474-C6D192CAE9AA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nice3point.Revit.Extensions", "source\Nice3point.Revit.Extensions\Nice3point.Revit.Extensions.csproj", "{C0F3E300-CBBB-4682-93AA-B13636690E20}"
 EndProject
@@ -12,13 +12,14 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9C7A67AC-A5FD-4133-8007-320A840ADBAC}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
-		Readme.md = Readme.md
-		Changelog.md = Changelog.md
 		build\Build.Configuration.cs = build\Build.Configuration.cs
+		Changelog.md = Changelog.md
+		Readme.md = Readme.md
 	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug R19|Any CPU = Debug R19|Any CPU
 		Debug R20|Any CPU = Debug R20|Any CPU
 		Debug R21|Any CPU = Debug R21|Any CPU
 		Debug R22|Any CPU = Debug R22|Any CPU
@@ -26,6 +27,7 @@ Global
 		Debug R24|Any CPU = Debug R24|Any CPU
 		Debug R25|Any CPU = Debug R25|Any CPU
 		Debug R26|Any CPU = Debug R26|Any CPU
+		Release R19|Any CPU = Release R19|Any CPU
 		Release R20|Any CPU = Release R20|Any CPU
 		Release R21|Any CPU = Release R21|Any CPU
 		Release R22|Any CPU = Release R22|Any CPU
@@ -36,21 +38,27 @@ Global
 		Release Tests|Any CPU = Release Tests|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Debug R19|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Debug R19|Any CPU.Build.0 = Debug|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Debug R20|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Debug R21|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Debug R22|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Debug R23|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Debug R24|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Debug R25|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Debug R26|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Release R19|Any CPU.ActiveCfg = Release|Any CPU
+		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Release R19|Any CPU.Build.0 = Release|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Release R20|Any CPU.ActiveCfg = Release|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Release R21|Any CPU.ActiveCfg = Release|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Release R22|Any CPU.ActiveCfg = Release|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Release R23|Any CPU.ActiveCfg = Release|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Release R24|Any CPU.ActiveCfg = Release|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Release R25|Any CPU.ActiveCfg = Release|Any CPU
-		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Debug R26|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Release R26|Any CPU.ActiveCfg = Release|Any CPU
 		{6A41E6AD-B176-4658-9474-C6D192CAE9AA}.Release Tests|Any CPU.ActiveCfg = Release|Any CPU
+		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R19|Any CPU.ActiveCfg = Debug R19|Any CPU
+		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R19|Any CPU.Build.0 = Debug R19|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R20|Any CPU.ActiveCfg = Debug R20|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R20|Any CPU.Build.0 = Debug R20|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R21|Any CPU.ActiveCfg = Debug R21|Any CPU
@@ -63,6 +71,10 @@ Global
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R24|Any CPU.Build.0 = Debug R24|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R25|Any CPU.ActiveCfg = Debug R25|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R25|Any CPU.Build.0 = Debug R25|Any CPU
+		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R26|Any CPU.ActiveCfg = Debug R26|Any CPU
+		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R26|Any CPU.Build.0 = Debug R26|Any CPU
+		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release R19|Any CPU.ActiveCfg = Release R19|Any CPU
+		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release R19|Any CPU.Build.0 = Release R19|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release R20|Any CPU.ActiveCfg = Release R20|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release R20|Any CPU.Build.0 = Release R20|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release R21|Any CPU.ActiveCfg = Release R21|Any CPU
@@ -75,27 +87,32 @@ Global
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release R24|Any CPU.Build.0 = Release R24|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release R25|Any CPU.ActiveCfg = Release R25|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release R25|Any CPU.Build.0 = Release R25|Any CPU
-		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R26|Any CPU.ActiveCfg = Debug R26|Any CPU
-		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Debug R26|Any CPU.Build.0 = Debug R26|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release R26|Any CPU.ActiveCfg = Release R26|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release R26|Any CPU.Build.0 = Release R26|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release Tests|Any CPU.ActiveCfg = Release R26|Any CPU
 		{C0F3E300-CBBB-4682-93AA-B13636690E20}.Release Tests|Any CPU.Build.0 = Release R26|Any CPU
+		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Debug R19|Any CPU.ActiveCfg = Debug|Any CPU
+		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Debug R19|Any CPU.Build.0 = Debug|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Debug R20|Any CPU.ActiveCfg = Debug|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Debug R21|Any CPU.ActiveCfg = Debug|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Debug R22|Any CPU.ActiveCfg = Debug|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Debug R23|Any CPU.ActiveCfg = Debug|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Debug R24|Any CPU.ActiveCfg = Debug|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Debug R25|Any CPU.ActiveCfg = Debug|Any CPU
+		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Debug R26|Any CPU.ActiveCfg = Debug|Any CPU
+		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release R19|Any CPU.ActiveCfg = Release|Any CPU
+		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release R19|Any CPU.Build.0 = Release|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release R20|Any CPU.ActiveCfg = Release|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release R21|Any CPU.ActiveCfg = Release|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release R22|Any CPU.ActiveCfg = Release|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release R23|Any CPU.ActiveCfg = Release|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release R24|Any CPU.ActiveCfg = Release|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release R25|Any CPU.ActiveCfg = Release|Any CPU
-		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Debug R26|Any CPU.ActiveCfg = Debug|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release R26|Any CPU.ActiveCfg = Release|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release Tests|Any CPU.ActiveCfg = Release|Any CPU
 		{15C9D243-223D-4B4F-BB2E-AB9BDE4AB4F9}.Release Tests|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/source/Nice3point.Revit.Extensions/Nice3point.Revit.Extensions.csproj
+++ b/source/Nice3point.Revit.Extensions/Nice3point.Revit.Extensions.csproj
@@ -8,8 +8,8 @@
         <ImplicitUsings>true</ImplicitUsings>
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
-        <Configurations>Debug R20;Debug R21;Debug R22;Debug R23;Debug R24;Debug R25;Debug R26</Configurations>
-        <Configurations>$(Configurations);Release R20;Release R21;Release R22;Release R23;Release R24;Release R25;Release R26</Configurations>
+        <Configurations>Debug R19;Debug R20;Debug R21;Debug R22;Debug R23;Debug R24;Debug R25;Debug R26</Configurations>
+        <Configurations>$(Configurations);Release R19;Release R20;Release R21;Release R22;Release R23;Release R24;Release R25;Release R26</Configurations>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -32,7 +32,10 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
-
+	<PropertyGroup Condition="$(Configuration.Contains('R19'))">
+		<RevitVersion>2019</RevitVersion>
+		<TargetFramework>net47</TargetFramework>
+	</PropertyGroup>
     <PropertyGroup Condition="$(Configuration.Contains('R20'))">
         <RevitVersion>2020</RevitVersion>
         <TargetFramework>net47</TargetFramework>


### PR DESCRIPTION
Description:
This PR adds support for Revit 2019 to the RevitExtensions library, aligning it with our project, which started from Revit 2019. The goal is to merge these changes into the main project so that RevitExtensions can be used seamlessly from R2019 to R2026.

Changes:

Added Revit 2019 support in the project configuration.

Updated build scripts and targets to include Revit 2019.

Ensured compatibility with existing R20–R26 features.

Next Steps:

After merging, please consider publishing the updated NuGet package to support all versions from 2019 onwards.
![Snipaste_2025-10-25_19-28-35](https://github.com/user-attachments/assets/889f2f70-613a-4b1f-b120-ca09df03b46b)

Notes:
This change is fully backward compatible with previous Revit versions supported by RevitExtensions.